### PR TITLE
feat: FitnessFunc can be dynamic with changing gene pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,33 @@ func genesis() []byte {
 }
 ```
 
-We need a `FitnessFunc[T]` which scores each genome on how many of its bytes match the target string. We'll use a minimum fitness of 1, which means our maximum fitness is 34.
+We need a `FitnessFunc[T]` which scores every genome on how many of its bytes match the target string. We'll use a minimum fitness of 1, which means our maximum fitness is 34.
 
 ```go
-func fitness(guess []byte) (fitness int) {
-  fitness = 1
-  for i, b := range guess {
-    if b == bytesToGuess[i] {
+func fitnessFn(guesses [][]byte, fitnesses []int) {
+  for i, guess := range guesses {
+    fitnesses[i] = 1
+    for j, b := range guess {
+      if b == bytesToGuess[j] {
+        fitnesses[i]++
+      }
+    }
+  }
+}
+```
+
+_Since this is a static fitness function (its output is not dependent on the other genomes in the population), we can optimize this slightly with the `StaticFitnessFunc` utility._
+
+```go
+fitnessFn := genetic.StaticFitnessFunc(func(guess []byte) int {
+  fitness := 1
+  for j, b := range guess {
+    if b == bytesToGuess[j] {
       fitness++
     }
   }
-  return
-}
+  return fitness
+})
 ```
 
 We need a `CrossoverFunc[T]` which combines two genomes together to produce offspring. `genetic` provides several simple crossover functions which work on any generic slice type genome. Let's use `UniformCrossover`, which produces offspring whose genomes are a random mix of their parents' genomes.

--- a/example_test.go
+++ b/example_test.go
@@ -28,16 +28,16 @@ func ExamplePopulation() {
 		// CrossoverFunc[[]byte] - combines two parent genomes into two new child genomes.
 		genetic.UniformCrossover[[]byte],
 
-		// FitnessFunc[[]byte] - determines how accurate the guess genome is.
-		func(guess []byte) (fitness int) {
-			fitness = 1
-			for i, b := range guess {
-				if b == bytesToGuess[i] {
+		// FitnessFunc[[]byte] - determines how accurate each guess genome is.
+		genetic.StaticFitnessFunc(func(guess []byte) int {
+			fitness := 1
+			for j, b := range guess {
+				if b == bytesToGuess[j] {
 					fitness++
 				}
 			}
-			return
-		},
+			return fitness
+		}),
 
 		// SelectionFunc[[]byte] - selects which genomes will reproduce.
 		genetic.TournamentSelection[[]byte](3),

--- a/fitness.go
+++ b/fitness.go
@@ -1,0 +1,15 @@
+package genetic
+
+// StaticFitnessFunc is a utility which maps a static non-competitive fitness function,
+// whose output is not dependent on other competing genomes, into a FitnessFunc[T].
+// Use this if your genomes' fitnesses are measured independently of the wider population.
+func StaticFitnessFunc[T any](fitness func(T) int) FitnessFunc[T] {
+	return func(genomes []T, fitnesses []int) {
+		for i, genome := range genomes {
+			if fitnesses[i] == 0 {
+				// Only calculate fitness for genomes whose fitnesses are unknown.
+				fitnesses[i] = fitness(genome)
+			}
+		}
+	}
+}

--- a/knapsack_benchmark_test.go
+++ b/knapsack_benchmark_test.go
@@ -15,7 +15,7 @@ func benchEvolveOnce(b *testing.B, selection genetic.SelectionFunc[*KnapsackSolu
 		populationSize,
 		problem.RandomSolution,
 		solutionCrossover,
-		solutionFitness,
+		genetic.StaticFitnessFunc(solutionFitness),
 		selection,
 		solutionMutation(0.02),
 	)

--- a/knapsack_problems_test.go
+++ b/knapsack_problems_test.go
@@ -86,7 +86,7 @@ func TestGenetic(t *testing.T) {
 			60,
 			perfectSolution.Problem.RandomSolution,
 			solutionCrossover,
-			solutionFitness,
+			genetic.StaticFitnessFunc(solutionFitness),
 			genetic.TournamentSelection[*KnapsackSolution](3),
 			solutionMutation(0.1),
 		)

--- a/vs_perfect_solution_test.go
+++ b/vs_perfect_solution_test.go
@@ -113,7 +113,7 @@ func TestAgainstPerfectSolutionAlgorithm(t *testing.T) {
 			50,
 			problem.RandomSolution,
 			solutionCrossover,
-			solutionFitness,
+			genetic.StaticFitnessFunc(solutionFitness),
 			genetic.TournamentSelection[*KnapsackSolution](3),
 			solutionMutation(0.02),
 		)


### PR DESCRIPTION
## Summary

Currently the fitness function signature only allows for static fitness functions which are deterministically derived from the genome itself. But in situations where genomes must compete for scarce resources, like natural selection, the fitness of any one genome is mutually dependent on the fitness of every other genome.


## Details

This PR changes the function signature of `FitnessFunc[T]`.

Old:

```go
type FitnessFunc[T any] func(genome T) int
```

New:
```go
type FitnessFunc[T any] func(allGenomes []T, fitnesses []int)
```

This way, fitness functions now have full context on the population, and can calculate fitness of each genome in a dynamic and customizable way. The results should be stored in the given `fitnesses` slice. 

For old-fashioned static fitness functions, a utility is available to convert them to the new `FitnessFunc[T]` type, optimizing to avoid recalculating the fitness of any cached elite genomes.

```go
// StaticFitnessFunc is a utility which maps a static non-competitive fitness function,
// whose output is not dependent on other competing genomes, into a FitnessFunc[T].
// Use this if your genomes' fitnesses are measured independently of the wider population.
func StaticFitnessFunc[T any](fitness func(T) int) FitnessFunc[T]
```


## Compatibility 

This change is backwards and forwards incompatible with `master`; this will need a new major version release.